### PR TITLE
add option parameter in exec of child process

### DIFF
--- a/lib/common/fs-operation.js
+++ b/lib/common/fs-operation.js
@@ -110,7 +110,7 @@ function FsOperationFactory(
     FsOperation.prototype._PromisedChildProcess = function PromisedChildProcess(command){
 
         return new Promise(function(resolve, reject){
-            return childProcess.exec(command, function (err, stdout, stderr) {
+            return childProcess.exec(command, {}, function (err, stdout, stderr) {
                 if (err) {
                     reject(err);
                 } else {


### PR DESCRIPTION
Fix a bug in node version > 4.8 about failing to run exec(). It is found that in the child process source code, the exec command without "options" argument will always fail. Adding an empty option when calling the function to work around this problem.
@nortonluo 